### PR TITLE
feature/ready-go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# vi swap files
+*.swp

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -10,6 +10,7 @@ export const RESIZE = 'RESIZE';
 export const SET_GAME_STATE = 'SET_GAME_STATE'
 export const SET_GAME_MODE = 'SET_GAME_MODE'
 export const SET_MENU = 'SET_MENU'
+export const UPDATE_READY = 'UPDATE_READY'
 export const UPDATE_TIMER = 'UPDATE_TIMER'
 export const UPDATE_CONFIG = 'UPDATE_CONFIG'
 export const LOAD_CONFIG = 'LOAD_CONFIG'
@@ -78,6 +79,11 @@ export const setGameMode = (newMode) => ({
 export const setMenu = (menu) => ({
   type: SET_MENU,
   menu: menu,
+});
+
+export const updateReady = (readyMillis) => ({
+  type: UPDATE_READY,
+  readyMillis: readyMillis,
 });
 
 export const updateTimer = (timerMillis) => ({

--- a/src/components/Canvas.jsx
+++ b/src/components/Canvas.jsx
@@ -4,6 +4,7 @@ import Field from './Field';
 import Piece from './Piece';
 import LineCount from './LineCount';
 import Timer from './Timer';
+import ReadyGo from './ReadyGo';
 import Button from './Button';
 import OrientationSelector from './OrientationSelector';
 import PreviewPiece from './PreviewPiece';
@@ -12,6 +13,7 @@ import {
   blockSizeInUnits,
   GAMEMODE_LINE_TARGET,
   passiveSupported,
+  totalReadyMillis,
 } from '../constants';
 
 class Canvas extends Component {
@@ -38,6 +40,8 @@ class Canvas extends Component {
     config: {
       blockStyles
     },
+    readyMillis,
+    readyAnimationIndex,
   } = props;
 
   const bagDisplay = props.previewSlots.map((ps, i) =>
@@ -107,6 +111,7 @@ class Canvas extends Component {
         blockSize={blockSizeInUnits} />
     : null);
 
+  const fieldClipId = "field-clip";
   return (
     <svg
       id="game-canvas"
@@ -126,6 +131,15 @@ class Canvas extends Component {
       onMouseUp={props.mouseUp}
       viewBox={viewBox}
     >
+      <defs>
+        <clipPath id={fieldClipId} >
+          <rect
+            x={fieldX}
+            y={fieldY}
+            width={fieldWidth}
+            height={fieldHeight} />
+        </clipPath>
+      </defs>
       <Field
         activePosition={props.activePosition}
         x={fieldX}
@@ -161,6 +175,14 @@ class Canvas extends Component {
         color="#3e3e3e"
         pressedColor="#292929"
         onPressed={props.mainMenu}
+      />
+      <ReadyGo
+        totalReadyMillis={totalReadyMillis}
+        remainingMillis={readyMillis}
+        animationIndex={readyAnimationIndex}
+        maskId={fieldClipId}
+        x={fieldX + fieldWidth/2}
+        y={fieldY + fieldHeight/2}
       />
     </svg>
   );

--- a/src/components/ReadyGo.css
+++ b/src/components/ReadyGo.css
@@ -1,0 +1,45 @@
+/* TODO: use some preprocessor that understands variables, e.g. sass or less
+ * so we can share values with the keyframes
+ */
+.ready, .go {
+  stroke-width: 6;
+  stroke: transparent;
+  fill: white;
+  font-size: 50pt;
+  font-weight: 500;
+  letter-spacing: 3pt;
+}
+
+.ready-outline, .go-outline {
+  stroke: #838383;
+}
+
+@keyframes go {
+  0% { font-size: 0pt; }
+  75% { font-size: 55pt; }
+  100% { font-size: 50pt; }
+}
+
+@keyframes ready-0 {
+  0% { transform: translate(-300pt,0); }
+  75% { transform: translate(10pt,0); }
+  100% { transform: translate(0,0); }
+}
+
+@keyframes ready-1 {
+  0% { transform: translate(300pt,0); }
+  75% { transform: translate(-10pt,0); }
+  100% { transform: translate(0,0); }
+}
+
+@keyframes ready-2 {
+  0% { transform: translate(0, 300pt); }
+  75% { transform: translate(0, -10pt); }
+  100% { transform: translate(0,0); }
+}
+
+@keyframes ready-3 {
+  0% { transform: translate(0, -300pt); }
+  75% { transform: translate(0, 10pt); }
+  100% { transform: translate(0,0); }
+}

--- a/src/components/ReadyGo.css
+++ b/src/components/ReadyGo.css
@@ -14,6 +14,14 @@
   stroke: #838383;
 }
 
+/* This allows react to generate the appropriate
+   vendor prefixes for 'animation' */
+.go { animation: go 250ms; }
+.ready-0 { animation: ready-0 250ms; }
+.ready-1 { animation: ready-1 250ms; }
+.ready-2 { animation: ready-2 250ms; }
+.ready-3 { animation: ready-3 250ms; }
+
 @keyframes go {
   0% { font-size: 0pt; }
   75% { font-size: 55pt; }

--- a/src/components/ReadyGo.jsx
+++ b/src/components/ReadyGo.jsx
@@ -23,17 +23,12 @@ const ReadyGo = (props) => {
 
   const showReady = remainingMillis > (totalReadyMillis / 2);
   const readyClass = showReady ? "ready" : "go";
-  const animMillis = 250;
-  const animation = (showReady
-    ? `ready-${animationIndex} ${animMillis}ms`
-    : `go ${animMillis}ms`
-  );
+  const animation = showReady ? `ready-${animationIndex}` : "";
 
   const textFill= <text
         x={x}
         y={y}
         className={readyClass}
-        style={ {animation: animation} }
         textAnchor="middle"
         alignmentBaseline="central"
         dominantBaseline="central"
@@ -43,9 +38,11 @@ const ReadyGo = (props) => {
 
   const textOutline = React.cloneElement(textFill, {className: `${readyClass} ${readyClass}-outline`});
   return (
-    <g clip-path={`url(#${maskId})`} >
-      {textOutline}
-      {textFill}
+    <g clipPath={`url(#${maskId})`} >
+      <g className={animation}>
+        {textOutline}
+        {textFill}
+      </g>
     </g>
   );
 };

--- a/src/components/ReadyGo.jsx
+++ b/src/components/ReadyGo.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import './ReadyGo.css';
+
+const ReadyGo = (props) => {
+  const {
+    totalReadyMillis,
+    remainingMillis,
+    animationIndex,
+    maskId,
+    x, y,
+  } = props;
+
+  if (remainingMillis <= 0) {
+    return null;
+  }
+
+  // ghetto hack to restart animation
+  // on repeated "reset"s
+  if (totalReadyMillis <= remainingMillis) {
+    return null;
+  }
+
+  const showReady = remainingMillis > (totalReadyMillis / 2);
+  const readyClass = showReady ? "ready" : "go";
+  const animMillis = 250;
+  const animation = (showReady
+    ? `ready-${animationIndex} ${animMillis}ms`
+    : `go ${animMillis}ms`
+  );
+
+  const textFill= <text
+        x={x}
+        y={y}
+        className={readyClass}
+        style={ {animation: animation} }
+        textAnchor="middle"
+        alignmentBaseline="central"
+        dominantBaseline="central"
+       >
+         {showReady ? 'READY' : 'GO'}
+       </text>;
+
+  const textOutline = React.cloneElement(textFill, {className: `${readyClass} ${readyClass}-outline`});
+  return (
+    <g clip-path={`url(#${maskId})`} >
+      {textOutline}
+      {textFill}
+    </g>
+  );
+};
+
+export default ReadyGo;

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,6 +2,7 @@ export const GAMESTATE_MENU = 'MENU';
 export const GAMESTATE_PLAYING = 'PLAYING';
 export const GAMESTATE_PAUSED = 'PAUSED';
 export const GAMESTATE_END = 'END';
+export const GAMESTATE_READY = 'READY';
 
 export const GAMEMODE_ZEN = 'ZEN';
 export const GAMEMODE_LINE_TARGET = 'LINE TARGET';
@@ -15,6 +16,8 @@ export const blockSizeInUnits = 26;
 export const fieldWidthInBlocks = 10;
 export const fieldHeightInBlocks = 20;
 export const hiddenHeight = 3;
+
+export const totalReadyMillis = 1500;
 
 export const defaultStyles = [
   { fill: '#708090' }, // I

--- a/src/containers/Game.js
+++ b/src/containers/Game.js
@@ -13,6 +13,7 @@ import {
   resize,
   setGameState,
   setGameMode,
+  updateReady,
   updateTimer,
   loadConfig,
 } from '../actions/index';
@@ -35,6 +36,7 @@ const mapStateToProps = state => ({
   windowWidth: state.windowWidth,
   windowHeight: state.windowHeight,
   timerMillis: state.timerMillis,
+  readyMillis: state.readyMillis,
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -70,6 +72,9 @@ const mapDispatchToProps = dispatch => ({
   },
   setGameMode: (newMode) => {
     dispatch(setGameMode(newMode));
+  },
+  updateReady: (readyMillis) => {
+    dispatch(updateReady(readyMillis));
   },
   updateTimer: (timerMillis) => {
     dispatch(updateTimer(timerMillis));

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ import {
   NEXT_PIECE,
   PLACE_BLOCK,
   CHECK_PLACEABILITY,
+  UPDATE_READY,
   UPDATE_STATS,
   UPDATE_TIMER,
   UPDATE_CONFIG,
@@ -22,6 +23,7 @@ import selectOrientation from './selectOrientation';
 import nextPiece from './nextPiece';
 import placeBlock from './placeBlock';
 import checkPlaceability from './checkPlaceability';
+import updateReady from './updateReady';
 import updateStats from './updateStats';
 import updateTimer from './updateTimer';
 import { loadConfig, updateConfig } from './config';
@@ -35,8 +37,9 @@ import { PIECE_NONE, ORIENTATION_NONE } from '../components/Piece';
 
 import {
   fieldWidthInBlocks, fieldHeightInBlocks,
-  GAMESTATE_MENU, GAMESTATE_PLAYING,
+  GAMESTATE_MENU, GAMESTATE_READY,
   defaultStyles,
+  totalReadyMillis,
 } from '../constants'
 
 const initialState = {
@@ -54,6 +57,7 @@ const initialState = {
   linesCleared: 0,
   lineTarget: 40,
   timerMillis: 0,
+  readyMillis: totalReadyMillis,
   field: {
     blocks :
       Array(fieldHeightInBlocks).fill(0).map(r =>
@@ -79,6 +83,8 @@ function reducer(state = initialState, action) {
       return placeBlock(state, action);
     case CHECK_PLACEABILITY:
       return checkPlaceability(state, action);
+    case UPDATE_READY:
+      return updateReady(state, action);
     case UPDATE_STATS:
       return updateStats(state, action);
     case UPDATE_TIMER:
@@ -104,7 +110,7 @@ function reducer(state = initialState, action) {
         windowWidth: state.windowWidth,
         windowHeight: state.windowHeight,
         gameMode: state.gameMode,
-        gameState: GAMESTATE_PLAYING,
+        gameState: GAMESTATE_READY,
       };
     default:
       return state;

--- a/src/reducers/updateReady.js
+++ b/src/reducers/updateReady.js
@@ -1,0 +1,10 @@
+export default (state, action) => {
+  if (state.readyMillis === action.readyMillis) {
+    return state;
+  }
+
+  return {
+    ...state,
+    readyMillis: action.readyMillis,
+  };
+};


### PR DESCRIPTION
This is the initial idea/implementation for a "ready/go" transition
screen between menu and game, and between games being reset.

I haven't tested it on iOS yet, and I'm not using any vendor-prefixes
/ haven't checked CSS compatibility charts so I suspect it won't work
(especially on older devices/browser versions). I don't yet know what
my minimum platform target is, but **if** it can be made to work
relatively consistently with "minimal" fuss, I want to at least try it
before I merge this.

(First pass at #5)